### PR TITLE
add the complete domain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 Page that redirects to a random page that offers the service you are looking for
 
 
-| subdomain                                          | server list                                          |
-| -------------------------------------------------- |:----------------------------------------------------:|
-| [jitsi](https://jitsi.random-redirect.de)          | [jitsi_servers.lst](/res/jitsi_servers.lst)          |
-| [poll](https://poll.random-redirect.de)            | [poll_servers.lst](/res/poll_servers.lst)            |
-| [pad](https://pad.random-redirect.de)              | [pad_servers.lst](/res/pad_servers.lst)              |
-| [codimd](https://codimd.random-redirect.de)        | [codimd_servers.lst](/res/codimd_servers.lst)        |
-| [cryptpad](https://cryptpad.random-redirect.de)    | [cryptpad_servers.lst](/res/cryptpad_servers.lst)    |
-| [etherpad](https://etherpad.random-redirect.de)    | [etherpad_servers.lst](/res/etherpad_servers.lst)    |
-| [ethercalc](https://ethercalc.random-redirect.de)  | [ethercalc_servers.lst](/res/ethercalc_servers.lst)  |
-| [bbb](https://bbb.random-redirect.de)              | [bbb_servers.lst](/res/bbb_servers.lst)              |
+| domain                                                                | server list                                    |
+| --------------------------------------------------------------------- |:----------------------------------------------:|
+| [jitsi.random-redirect.de](https://jitsi.random-redirect.de)          | [jitsi_servers.lst](/res/jitsi_servers.lst)          |
+| [poll.random-redirect.de](https://poll.random-redirect.de)            | [poll_servers.lst](/res/poll_servers.lst)            |
+| [pad.random-redirect.de](https://pad.random-redirect.de)              | [pad_servers.lst](/res/pad_servers.lst)              |
+| [codimd.random-redirect.de](https://codimd.random-redirect.de)        | [codimd_servers.lst](/res/codimd_servers.lst)        |
+| [cryptpad.random-redirect.de](https://cryptpad.random-redirect.de)    | [cryptpad_servers.lst](/res/cryptpad_servers.lst)    |
+| [etherpad.random-redirect.de](https://etherpad.random-redirect.de)    | [etherpad_servers.lst](/res/etherpad_servers.lst)    |
+| [ethercalc.random-redirect.de](https://ethercalc.random-redirect.de)  | [ethercalc_servers.lst](/res/ethercalc_servers.lst)  |
+| [bbb.random-redirect.de](https://bbb.random-redirect.de)              | [bbb_servers.lst](/res/bbb_servers.lst)              |


### PR DESCRIPTION
I think the domain makes it clearer that you can click directly on it, right?


Looks like:

![grafik](https://user-images.githubusercontent.com/71315/81317163-c9949300-908c-11ea-93cd-54fa2f409f8f.png)
