### PR TITLE
Remove meet.teckids.org

### DIFF
--- a/res/jitsi_servers.lst
+++ b/res/jitsi_servers.lst
@@ -89,7 +89,6 @@ https://meet.spielmannsolutions.com/
 https://meet.stura.uni-heidelberg.de/
 https://meet.systemli.org/
 https://meet.teamcloud.work/
-https://meet.teckids.org/
 https://meet.tellifon.ch/
 https://meet.ubergeek.cx/
 https://meet.weimarnetz.de/


### PR DESCRIPTION
meet.teckids.org is intended for use by educational institutions who somewhat rely on its performance, and the operators were never asked whether they want it to be offered to everyone,