### PR TITLE
add drive.allmende.io

### DIFF
--- a/res/cryptpad_servers.lst
+++ b/res/cryptpad_servers.lst
@@ -5,3 +5,4 @@ https://cryptpad.piratenpartei.de/
 https://cryptpad.raspberryblog.de/
 https://cryptpad.uber.space/
 https://pads.c3w.at/
+https://drive.allmende.io/


### PR DESCRIPTION
This adds drive.allmende.io.

There are currently no terms of service, but *no warranty* as stated on allmende.io