### PR TITLE
Removed jitsi.netways.de from Jitsi server

### DIFF
--- a/res/jitsi_servers.lst
+++ b/res/jitsi_servers.lst
@@ -29,7 +29,6 @@ https://jitsi.linux.it/
 https://jitsi.math.uzh.ch/
 https://jitsi-meet.hs-nb.de/
 https://jitsi.mpi-bremen.de/
-https://jitsi.netways.de/
 https://jitsi.php-friends.de/
 https://jitsi.piratenpartei-duesseldorf.de/
 https://jitsi.q2r.net/


### PR DESCRIPTION
Meetings can only start with a non public password