### PR TITLE
Remove jitsi.debian.social

### DIFF
--- a/res/jitsi_servers.lst
+++ b/res/jitsi_servers.lst
@@ -1,7 +1,6 @@
 https://besprechung.net/
 https://fairmeeting.net/
 https://freejitsi01.netcup.net/
-https://jitsi.debian.social/
 https://jitsi.dorf-post.de/
 https://jitsi.eichstaett.social/
 https://jitsi.fem.tu-ilmenau.de/


### PR DESCRIPTION
It's no longer a public server: an attempt to join a new meeting results in a redirect to their gitlab login page that allows only manually approved accounts.

<img width="2765" height="384" alt="debian" src="https://github.com/user-attachments/assets/237722db-e2b4-4210-90e9-43894d2a73c3" />
