### PR TITLE
remove nerd.re jitsi relocation

### DIFF
--- a/res/jitsi_servers.lst
+++ b/res/jitsi_servers.lst
@@ -64,7 +64,6 @@ https://meet.leinelab.org/
 https://meet.linus-neumann.de/
 https://meet.lug-stormarn.de/
 https://meet.meerfarbig.net/
-https://meet.nerd.re/
 https://meet.opensuse.org/
 https://meet.osna.social/
 https://meet.physnet.uni-hamburg.de/


### PR DESCRIPTION
nerd.re only hosts matrix now