### PR TITLE
Update jitsi_servers.lst

### DIFF
--- a/res/jitsi_servers.lst
+++ b/res/jitsi_servers.lst
@@ -86,7 +86,7 @@ https://noalyss.free-solutions.org/
 https://onlinetreff.ash-berlin.eu/
 https://open.meet.switch.ch/
 https://swisschat.free-solutions.org/
-https://talk.linux-whv.de
+https://meet.linux-whv.de
 https://talk.snopyta.org/
 https://unibe.meet.switch.ch/
 https://unifr.meet.switch.ch/


### PR DESCRIPTION
Server domain of talk.linux-whv.de has changed to meet.linux-whv.de